### PR TITLE
Add support for latest Mongooose. Fix "Failed to load c++ bson extension." Update tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,18 +16,19 @@
     "url": "git://github.com/swayf/mongoose-path-tree.git"
   },
   "main": "index.js",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "engine": "node >= 0.8.0",
   "dependencies": {
-    "mongoose": "3.8.x",
-    "stream-worker": "0.x.x"
+    "mongoose": "4.3.5",
+    "stream-worker": "0.x.x",
+    "kerberos": "0.0.17"
   },
   "devDependencies": {
-    "async": "0.x.x",
-    "should": "1.x.x",
-    "lodash": "2.x.x",
-    "mocha": "1.x.x",
-    "shortid": "2.0.0"
+    "async": "1.5.x",
+    "should": "8.1.x",
+    "lodash": "4.0.x",
+    "mocha": "2.3.x",
+    "shortid": "2.2.x"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/swayf/mongoose-path-tree.git"
   },
   "main": "index.js",
-  "version": "1.4.0",
+  "version": "1.3.6",
   "engine": "node >= 0.8.0",
   "dependencies": {
     "mongoose": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "version": "1.3.6",
   "engine": "node >= 0.8.0",
   "dependencies": {
-    "mongoose": "4.3.5",
+    "mongoose": "4.3.x",
     "stream-worker": "0.x.x",
     "kerberos": "0.0.17"
   },

--- a/test/tree.js
+++ b/test/tree.js
@@ -102,7 +102,7 @@ describe('tree tests', function () {
 
                         should.not.exist(err);
                         users.length.should.equal(5);
-                        _.pluck(users, 'name').should.not.include('Emily');
+                        _.map(users, 'name').should.not.containEql('Emily');
                         done();
                     });
                 });
@@ -124,7 +124,7 @@ describe('tree tests', function () {
                         should.not.exist(err);
 
                         users.length.should.equal(3);
-                        _.pluck(users, 'name').should.include('Adam').and.include('Bob');
+                        _.map(users, 'name').should.containEql('Adam').and.containEql('Bob');
                         done();
                     });
                 });
@@ -196,7 +196,7 @@ describe('tree tests', function () {
 
                     should.not.exist(err);
                     users.length.should.equal(1);
-                    _.pluck(users, 'name').should.include('Bob');
+                    _.map(users, 'name').should.containEql('Bob');
                     done();
                 });
             });
@@ -213,7 +213,7 @@ describe('tree tests', function () {
                     should.not.exist(err);
 
                     users.length.should.equal(2);
-                    _.pluck(users, 'name').should.include('Bob').and.include('Carol');
+                    _.map(users, 'name').should.containEql('Bob').and.containEql('Carol');
                     done();
                 });
             });
@@ -230,7 +230,7 @@ describe('tree tests', function () {
                     should.not.exist(err);
 
                     users.length.should.equal(2);
-                    _.pluck(users, 'name').should.include('Dann').and.include('Emily');
+                    _.map(users, 'name').should.containEql('Dann').and.containEql('Emily');
                     done();
                 });
             });
@@ -246,9 +246,9 @@ describe('tree tests', function () {
 
                     should.not.exist(err);
 
-                    users.length.should.equal(2);
-                    users[0].should.not.have.property('parent');
-                    _.pluck(users, 'name').should.include('Dann').and.include('Emily');
+                    users.length.should.be.exactly(2);
+                    users[0].should.not.have.propertyWithDescriptor('parent');
+                    _.map(users, 'name').should.containEql('Dann').and.containEql('Emily');
                     done();
                 });
             });
@@ -266,7 +266,7 @@ describe('tree tests', function () {
 
                     users.length.should.equal(2);
                     users[0].name.should.equal('Emily');
-                    _.pluck(users, 'name').should.include('Dann').and.include('Emily');
+                    _.map(users, 'name').should.containEql('Dann').and.containEql('Emily');
                     done();
                 });
             });
@@ -299,7 +299,7 @@ describe('tree tests', function () {
 
                     should.not.exist(err);
                     ancestors.length.should.equal(2);
-                    _.pluck(ancestors, 'name').should.include('Carol').and.include('Adam');
+                    _.map(ancestors, 'name').should.containEql('Carol').and.containEql('Adam');
                     done();
                 });
             });
@@ -313,10 +313,10 @@ describe('tree tests', function () {
                 dann.getAncestors({}, 'name', function (err, ancestors) {
                     should.not.exist(err);
 
-                    ancestors.length.should.equal(2);
-                    ancestors[0].should.not.have.property('parent');
+                    ancestors.length.should.be.exactly(2);
+                    ancestors[0].should.not.have.propertyWithDescriptor('parent');
                     ancestors[0].should.have.property('name');
-                    _.pluck(ancestors, 'name').should.include('Carol').and.include('Adam');
+                    _.map(ancestors, 'name').should.containEql('Carol').and.containEql('Adam');
                     done();
                 });
             });
@@ -333,7 +333,7 @@ describe('tree tests', function () {
                     ancestors.length.should.equal(2);
                     ancestors[0].name.should.equal('Carol');
                     should.not.exist(ancestors[0].getAncestors);
-                    _.pluck(ancestors, 'name').should.include('Carol').and.include('Adam');
+                    _.map(ancestors, 'name').should.containEql('Carol').and.containEql('Adam');
                     done();
                 });
             });


### PR DESCRIPTION
Thanks for the great project!

I was running into the following runtime error with the latest `mongoose` and `mongodb` (with potentially large performance implications):

```
{ [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }
js-bson: Failed to load c++ bson extension, using pure JS version
```

A quick search turned up plenty of fixes via simply bumping dependencies. I first tested this by updating `mongoose` to `4.3.5` and running `npm rebuild` in my project's `node_modules/mongoose-tree`.

This PR includes:
* Updated `mongoose` to `4.3.5`
* Added `kerberos 0.0.17` peer dependency
* Updated dev dependencies with latest versions
* Updated tests for new lodash and should APIs