### PR TITLE
Bump mongoose dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "version": "1.3.5",
   "engine": "node >= 0.8.0",
   "dependencies": {
-    "mongoose": "3.8.x",
+    "mongoose": "4.4.x",
     "stream-worker": "0.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This solves "{ [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }" error.