### PR TITLE
update children path when parent is removed

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -55,21 +55,12 @@ function tree(schema, options) {
 
         if (this.isNew || isParentChange) {
             if (!this.parent) {
+                var previousPath = this.path;
                 this.path = this._id.toString();
-                return next();
-            }
-
-            var self = this;
-            this.collection.findOne({ _id: this.parent }, function (err, doc) {
-
-                if (err) {
-                    return next(err);
-                }
-
-                var previousPath = self.path;
-                self.path = doc.path + pathSeparator + self._id.toString();
 
                 if (isParentChange) {
+                    var self = this;
+
                     // When the parent is changed we must rewrite all children paths as well
                     self.collection.find({ path: { '$regex': '^' + previousPath + pathSeparatorRegex } }, function (err, cursor) {
 
@@ -84,11 +75,42 @@ function tree(schema, options) {
                         },
                         next);
                     });
-                }
-                else {
+                } else {
                     next();
                 }
-            });
+            } else {
+
+                var self = this;
+                this.collection.findOne({ _id: this.parent }, function (err, doc) {
+    
+                    if (err) {
+                        return next(err);
+                    }
+    
+                    var previousPath = self.path;
+                    self.path = doc.path + pathSeparator + self._id.toString();
+    
+                    if (isParentChange) {
+                        // When the parent is changed we must rewrite all children paths as well
+                        self.collection.find({ path: { '$regex': '^' + previousPath + pathSeparatorRegex } }, function (err, cursor) {
+    
+                            if (err) {
+                                return next(err);
+                            }
+    
+                            streamWorker(cursor.stream(), numWorkers, function streamOnData(doc, done) {
+    
+                                var newPath = self.path + doc.path.substr(previousPath.length);
+                                self.collection.update({ _id: doc._id }, { $set: { path: newPath } }, done);
+                            },
+                            next);
+                        });
+                    }
+                    else {
+                        next();
+                    }
+                });
+            }
         }
         else {
             next();


### PR DESCRIPTION
Previously, children path is not updated when a parent is removed. 
For example, lets three path be (i changed _id to readable name):

- COMPUTER
- COMPUTER#LAPTOP
- COMPUTER#LAPTOP#DELL

When COMPUTER is removed as parent from LAPTOP, the path will become:

- COMPUTER
- LAPTOP
- COMPUTER#LAPTOP#DELL

This is because from line 57 to 60 in original tree.js, path without parent is directly change to itself but ignored their children.