### PR TITLE
Peer dependecy with ci tests & up'd node versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - "0.11"
   - "0.10"
   - "0.8"
+after_install:
+  - "./node_modules/.bin/npm-install-peers"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 services: mongodb
 node_js:
-  - "0.11"
-  - "0.10"
-  - "0.8"
+  - "6.0"
+  - "5.0"
+  - "4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,3 @@ node_js:
   - "0.11"
   - "0.10"
   - "0.8"
-after_install:
-  - "./node_modules/.bin/npm-install-peers"

--- a/README.md
+++ b/README.md
@@ -193,12 +193,6 @@ carol.level; // equals 3
 
 # Tests
 
-To run the tests install mocha
+To run the tests simply run
 
-    npm install mocha -g
-
-and then run
-
-    mocha
-
-
+    npm test

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "test"
   },
   "scripts": {
+    "pretest": "./node_modules/.bin/npm-install-peers",
     "test": "MONGOOSE_TREE_SHORTID=1 ./node_modules/.bin/mocha && MONGOOSE_TREE_SHORTID=0 ./node_modules/.bin/mocha"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   },
   "devDependencies": {
     "async": "0.x.x",
-    "should": "1.x.x",
     "lodash": "2.x.x",
     "mocha": "1.x.x",
-    "shortid": "2.0.0"
+    "npm-install-peers": "1.0.1",
+    "shortid": "2.0.0",
+    "should": "1.x.x"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   "version": "1.3.5",
   "engine": "node >= 0.8.0",
   "dependencies": {
-    "mongoose": "3.8.x",
     "stream-worker": "0.x.x"
+  },
+  "peerDependencies": {
+    "mongoose": ">=3.8.x"
   },
   "devDependencies": {
     "async": "0.x.x",
@@ -42,5 +44,5 @@
     "tree",
     "mongodb"
   ],
-  "license": "BSD"
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
I had an issue when using this module in that it directly depends on mongoose which is an issue for later versions. Making it a peer dependency solves this problem. I also fixed the NPM license warning.

Made mongoose a peer dependency and fixed the BSD license clause.
Updated tests to install peer dependencies before hand.
Updated README.
Updated node versions to 4,5 & 6.